### PR TITLE
Tweak whitelisted licenses

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -3,4 +3,5 @@ whitelist:
   - Apache-2.0
   - FreeBSD
   - MIT
-  - NewBSD
+  - BSD-2-Clause
+  - BSD-3-Clause


### PR DESCRIPTION
Wwhrd changed its license detection library. The new library detects the previous "NewBSD" as "BSD-2-Clause" and "BSD-3-Clause".