### PR TITLE
Test Go unstable version 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arnested/sshfpgo
 
-go 1.19
+go 1.22.0
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0


### PR DESCRIPTION
Test Go unstable version 1.22.0.

See [the draft release notes](https://tip.golang.org/doc/go1.22).

This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!