### PR TITLE
Update Go version to 1.22.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arnested/sshfpgo
 
-go 1.22.0
+go 1.22.1
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0


### PR DESCRIPTION
Update Go version to 1.22.1.

See [the release history](https://go.dev/doc/devel/release#go1.22.1).