### PR TITLE
Update Go version to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arnested/sshfpgo
 
-go 1.22.6
+go 1.23.0
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0


### PR DESCRIPTION
Update Go version to 1.23.0.

See [the release history](https://go.dev/doc/devel/release#go1.23.0).