### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arnested

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       time: '04:00'
       timezone: Europe/Copenhagen
     open-pull-requests-limit: 10
-    reviewers:
-      - arnested
   - package-ecosystem: gomod
     directory: "/"
     schedule:
@@ -17,5 +15,3 @@ updates:
       time: '04:00'
       timezone: Europe/Copenhagen
     open-pull-requests-limit: 10
-    reviewers:
-      - arnested


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
