### PR TITLE
Test Go unstable version 1.25rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arnested/sshfpgo
 
-go 1.24.4
+go 1.25rc1
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0


### PR DESCRIPTION
Test Go unstable version 1.25rc1.

See [the draft release notes](https://tip.golang.org/doc/go1.25).

This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!